### PR TITLE
Pin CodeQL GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/tools_codeql.yml
+++ b/.github/workflows/tools_codeql.yml
@@ -57,7 +57,7 @@ jobs:
             # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       # Add any setup steps before running the `github/codeql-action/init` action.
       # This includes steps like installing compilers or runtimes (`actions/setup-node`
       # or others). This is typically only required for manual builds.
@@ -66,7 +66,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -94,6 +94,6 @@ jobs:
           exit 1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4.35.1
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
This PR updates the CodeQL workflow configuration by pinning all referenced GitHub Actions to specific commit SHAs.

### 🔒 What Changed
- Replaced floating version tags (e.g., `@v1`, `@v2`) in CodeQL workflows with exact commit SHA references.
- Ensured all CodeQL-related actions use immutable versions.
- Standardized version pinning across the workflow for consistency.

### 🛡️ Why
Using mutable tags for GitHub Actions can introduce unintended changes or supply chain risks if upstream code changes. Pinning to commit SHAs ensures:
- Improved security by using immutable references
- Reproducible and deterministic CI runs
- Better auditability of workflow dependencies

### ⚙️ Context
CodeQL is used for automated security analysis in CI pipelines, and consistent execution environments are important to avoid unexpected scan differences. :contentReference[oaicite:0]{index=0}

### ⚠️ Notes
- No functional changes expected; this is a security hardening change.
- Future updates to CodeQL actions require explicitly updating the pinned SHAs.