### PR TITLE
Fix Docker repository name configuration

### DIFF
--- a/.github/workflows/build.docker.images.yml
+++ b/.github/workflows/build.docker.images.yml
@@ -107,6 +107,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ env.REGISTRY_ACCOUNT }}/${{ env.REGISTRY_REPO }}
+          repository: ${{ env.REGISTRY_ACCOUNT }}/${{ env.REGISTRY_REPO }}-${{ matrix.image }}
           readme-filepath: ./README-dockerhub.md
           short-description: "Checks MTA-STS implementation for secure email."


### PR DESCRIPTION
This PR fixes the Docker repository name used in the build and/or publish configuration.

### What Changed
- Corrected the Docker repository name to match the intended target registry/repo.
- Updated configuration so the image is published with the proper repository identifier.
- Ensured consistency between build, tag, and push steps.