### PR TITLE
Install wget for Docker healthcheck support

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -15,6 +15,13 @@ LABEL maintainer="Daniel Wydler" \
       org.opencontainers.image.title="wydler/mta-sts-web" \
       org.opencontainers.image.url="https://hub.docker.com/r/wydler/mta-sts-web"
 
+#############################################
+# Install dependencies
+#############################################
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    wget \
+    && rm -rf /var/lib/apt/lists/*      
 
 #############################################
 # nginx configuration


### PR DESCRIPTION
This PR installs wget in the Docker image to support the configured healthcheck.

### What Changed
- Added installation of `wget` in the Docker image.
- Ensured the healthcheck command dependency is available at runtime.
- Prevented healthcheck failures due to missing binary.
