### PR TITLE
Replace wget with curl in Docker healthcheck

### DIFF
--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -45,4 +45,4 @@ RUN chown -R nginx:nginx /var/www/html/mta-sts
 # Prüft regelmäßig, ob der Webserver erreichbar ist
 #############################################
 HEALTHCHECK --interval=30s --timeout=3s \
-  CMD wget -qO- http://localhost/ || exit 1
+  CMD curl -f http://localhost/ || exit 1


### PR DESCRIPTION
This PR replaces wget with curl in the Docker healthcheck command.

### What Changed
- Updated the Docker HEALTHCHECK to use `curl` instead of `wget`.
- Adjusted healthcheck command to use a more suitable HTTP client for container environments.
- Removed dependency on `wget` for healthcheck execution.