### PR TITLE
Migrate base image from Ubuntu 22.04 to 24.04

### DIFF
--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -41,12 +41,11 @@ RUN apt-get update && \
 # Python dependencies (via pip)
 #############################################
 COPY docker/ubuntu/requirements.txt /app
-RUN python3 -m venv venv \
-    && source venv/bin/activate \
-    && pip install --no-cache-dir -r /app/requirements.txt \
-    && deactivate \
-    && rm -rf /app
+RUN python3 -m venv /app/venv \
+    && /app/venv/bin/pip install --no-cache-dir -r /app/requirements.txt \
+    && rm -r /app/requirements.txt
 
+ENV PATH="/app/venv/bin:$PATH"
 
 
 #############################################

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # Stage 1: Runtime
 ############################
-FROM ubuntu:22.04@sha256:962f6cadeae0ea6284001009daa4cc9a8c37e75d1f5191cf0eb83fe565b63dd7
+FROM ubuntu:24.04@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
 
 
 # Setze Arbeitsverzeichnis für temporäre Dateien

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
     python3-cryptography \
     python3-flask \
     python3-flask-limiter \
+    python3.12-venv \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -40,7 +41,10 @@ RUN apt-get update && \
 # Python dependencies (via pip)
 #############################################
 COPY docker/ubuntu/requirements.txt /app
-RUN pip install --no-cache-dir -r /app/requirements.txt \
+RUN python3 -m venv venv \
+    && source venv/bin/activate \
+    && pip install --no-cache-dir -r /app/requirements.txt \
+    && deactivate \
     && rm -rf /app
 
 

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && \
     python3-pip \
     python3-cryptography \
     python3-flask \
+    python3-flask-limiter \
     && rm -rf /var/lib/apt/lists/*
 
 

--- a/docker/ubuntu/requirements.txt
+++ b/docker/ubuntu/requirements.txt
@@ -1,2 +1,1 @@
 uwsgitop
-Flask-Limiter

--- a/renovate.json5
+++ b/renovate.json5
@@ -78,7 +78,7 @@
         'ubuntu',
       ],
       versioning: 'ubuntu',
-      allowedVersions: '22.04',
+      allowedVersions: '24.04',
       pinDigests: true,
       labels: [
         'dependencies',


### PR DESCRIPTION
This PR updates the Docker base image from Ubuntu 22.04 (Jammy) to Ubuntu 24.04 (Noble).

### What Changed
- Updated the base image in the Dockerfile to Ubuntu 24.04.
- Adjusted package installation and dependencies as required for the new release.
- Ensured compatibility with updated system libraries and toolchain.