### PR TITLE
Fix incorrect repository name in git submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rootfs/mta-sts"]
 	path = rootfs/mta-sts
-	url = https://github.com/dwydler/mta-sts.git
+	url = https://github.com/wydler/mta-sts.git


### PR DESCRIPTION
This PR fixes an incorrect repository name in the git submodule configuration.

### What Changed
- Updated the submodule repository reference to use the correct repository name.
- Fixed the URL and/or configuration in `.gitmodules`.
- Ensured the submodule points to the intended upstream repository.