### PR TITLE
Enable git-submodules management in Renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -13,7 +13,9 @@
     'github-actions',
     'dockerfile',
   ],
-
+  git-submodules: {
+    enabled: true,
+  },
 
   packageRules: [
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,6 +29,23 @@
     },
     {
       // ===========================================================================
+      // GitSubmodule
+      // ===========================================================================
+      matchManagers: [
+        'git-submodules',
+      ],      
+      labels: [
+        'dependencies',
+        'github_actions',
+      ],
+      draftPR: true,
+      additionalBranchPrefix: 'git_submodule/',
+      branchTopic: '{{depNameSanitized}}-{{#if newVersion}}{{newVersion}}{{else}}{{currentValue}}-{{newDigest}}{{/if}}',
+      commitMessageTopic: '{{depName}}',
+      commitMessageExtra: '{{#if newVersion}}from {{currentVersion}} to {{newVersion}}{{else}}{{newValue}} from {{currentDigestShort}} to {{newDigestShort}}{{/if}}',      
+    },    
+    {
+      // ===========================================================================
       // GitHub Actions
       // ===========================================================================  
       matchManagers: [

--- a/renovate.json5
+++ b/renovate.json5
@@ -36,7 +36,7 @@
       ],      
       labels: [
         'dependencies',
-        'github_actions',
+        'submodules',
       ],
       draftPR: true,
       additionalBranchPrefix: 'git_submodule/',


### PR DESCRIPTION
Configure Renovate to manage git-submodules by enabling the feature and adding specific rules for handling submodule dependencies.