### PR TITLE
Correctly enable git-submodules in Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,9 +12,7 @@
   enabledManagers: [
     'github-actions',
     'dockerfile',
-  ],
-  git-submodules: [
-    enabled: true,
+    'git-submodules',
   ],
 
   packageRules: [


### PR DESCRIPTION
Update the Renovate configuration to properly enable git-submodules as a managed manager.