### PR TITLE
Revert "Correctly enable git-submodules in Renovate configuration"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -12,7 +12,9 @@
   enabledManagers: [
     'github-actions',
     'dockerfile',
-    'git-submodules',
+  ],
+  git-submodules: [
+    enabled: true,
   ],
 
   packageRules: [


### PR DESCRIPTION
Reverts wydler/mta-sts-docker#116