### PR TITLE
Enable git-submodules support in Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,6 +15,7 @@
   enabledManagers: [
     'github-actions',
     'dockerfile',
+    'git-submodules',
   ],
 
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -94,5 +94,22 @@
       commitMessageTopic: '{{depName}}',
       commitMessageExtra: '{{#if newVersion}}from {{currentVersion}} to {{newVersion}}{{else}}{{newValue}} from {{currentDigestShort}} to {{newDigestShort}}{{/if}}',
     },
+    {
+      // ===========================================================================
+      // Git Submodules
+      // ===========================================================================
+      matchManagers: [
+        'git-submodules',
+      ],
+      labels: [
+        'dependencies',
+        'git_submodules',
+      ],
+      draftPR: true,
+      additionalBranchPrefix: 'git_submodule/',
+      branchTopic: '{{depNameSanitized}}-{{#if newVersion}}{{newVersion}}{{else}}{{currentValue}}-{{newDigest}}{{/if}}',
+      commitMessageTopic: '{{depName}}',
+      commitMessageExtra: '{{#if newVersion}}from {{currentVersion}} to {{newVersion}}{{else}}{{newValue}} from {{currentDigestShort}} to {{newDigestShort}}{{/if}}',   
+    },    
   ],
 }


### PR DESCRIPTION
Add support for managing git-submodules in the Renovate configuration, allowing for better dependency management and updates for submodules. This change enhances the overall functionality of the Renovate tool.