### PR TITLE
Enable git-submodules support in Renovate configuration

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -18,6 +18,9 @@
     'git-submodules',
   ],
 
+  git-submodules: {
+    enabled: true,
+  },
 
   packageRules: [
     {


### PR DESCRIPTION
Enable support for git-submodules in the Renovate configuration to enhance dependency management.